### PR TITLE
Feat/owned ingredients endpoints

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -14,6 +14,7 @@ import {
 import { initModels, Recipe } from './models/init-models';
 import { RecipeData } from './types/recipeData';
 import sequelize from './db/client';
+import ownedIngredientsRouter from './routes/ownedIngredients';
 
 const app: Express = express();
 
@@ -154,6 +155,7 @@ app.post('/recipes', async (req: Request, res: Response, next: NextFunction) => 
     }
 });
 
+app.use('/ownedIngredients', ownedIngredientsRouter);
 
 /**
  * @brief global error handler

--- a/backend/src/controllers/ownedIngredient.ts
+++ b/backend/src/controllers/ownedIngredient.ts
@@ -8,6 +8,7 @@ export const getOwnedIngredients = async (): Promise<OwnedIngredient[]> => {
         include: [
             {
                 model: Ingredient,
+                as: 'ingredient',
                 attributes: ['name', 'description', 'standard_unit', 'density'],
             },
         ],

--- a/backend/src/controllers/ownedIngredient.ts
+++ b/backend/src/controllers/ownedIngredient.ts
@@ -25,6 +25,7 @@ export const getOwnedIngredientById = async (
         include: [
             {
                 model: Ingredient,
+                as: 'ingredient',
                 attributes: ['name', 'description', 'standard_unit', 'density'],
             },
         ],

--- a/backend/src/routes/ownedIngredients.ts
+++ b/backend/src/routes/ownedIngredients.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getOwnedIngredients } from '../controllers/ownedIngredient';
+
+const router = Router();
+
+/**
+ * @brief endpoint for getting all owned ingredients
+ */
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const ingredients = await getOwnedIngredients();
+        res.status(200).json(ingredients);
+    } catch (error) {
+        next(error);
+    }
+});
+
+export default router;

--- a/backend/src/routes/ownedIngredients.ts
+++ b/backend/src/routes/ownedIngredients.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { getOwnedIngredients } from '../controllers/ownedIngredient';
+import { getOwnedIngredients, createOwnedIngredient } from '../controllers/ownedIngredient';
 
 const router = Router();
 
@@ -10,6 +10,23 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
     try {
         const ingredients = await getOwnedIngredients();
         res.status(200).json(ingredients);
+    } catch (error) {
+        next(error);
+    }
+});
+
+/**
+ * @brief endpoint for creating a new owned ingredient
+ */
+router.post('/', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+        const { ingredientId, quantity } = req.body;
+        if (!ingredientId || quantity === undefined) {
+            res.status(400).json({ error: 'ingredientId and quantity are required' });
+            return;
+        }
+        const ownedIngredient = await createOwnedIngredient(ingredientId, quantity);
+        res.status(201).json(ownedIngredient);
     } catch (error) {
         next(error);
     }

--- a/backend/src/routes/ownedIngredients.ts
+++ b/backend/src/routes/ownedIngredients.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { getOwnedIngredients, createOwnedIngredient } from '../controllers/ownedIngredient';
+import { getOwnedIngredients, createOwnedIngredient, getOwnedIngredientById, updateOwnedIngredient } from '../controllers/ownedIngredient';
 
 const router = Router();
 
@@ -16,7 +16,7 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
 });
 
 /**
- * @brief endpoint for creating a new owned ingredient
+ * @brief endpoint for creating a new owned ingredient or updating an existing one
  */
 router.post('/', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
@@ -25,7 +25,30 @@ router.post('/', async (req: Request, res: Response, next: NextFunction): Promis
             res.status(400).json({ error: 'ingredientId and quantity are required' });
             return;
         }
-        const ownedIngredient = await createOwnedIngredient(ingredientId, quantity);
+
+        // Ensure quantity is a number
+        const numericQuantity = Number(quantity);
+        if (isNaN(numericQuantity)) {
+            res.status(400).json({ error: 'quantity must be a valid number' });
+            return;
+        }
+
+        // Check if ingredient is already owned
+        const existingIngredient = await getOwnedIngredientById(ingredientId);
+        if (existingIngredient) {
+            // Update the quantity by adding the new quantity to the existing one
+            await updateOwnedIngredient(ingredientId, numericQuantity);
+            const updatedIngredient = await getOwnedIngredientById(ingredientId);
+            res.status(200).json({ 
+                message: 'Ingredient quantity updated', 
+                ingredientId, 
+                newQuantity: updatedIngredient?.quantity 
+            });
+            return;
+        }
+
+        // If ingredient doesn't exist, create a new one
+        const ownedIngredient = await createOwnedIngredient(ingredientId, numericQuantity);
         res.status(201).json(ownedIngredient);
     } catch (error) {
         next(error);

--- a/backend/src/routes/ownedIngredients.ts
+++ b/backend/src/routes/ownedIngredients.ts
@@ -37,7 +37,8 @@ router.post('/', async (req: Request, res: Response, next: NextFunction): Promis
         const existingIngredient = await getOwnedIngredientById(ingredientId);
         if (existingIngredient) {
             // Update the quantity by adding the new quantity to the existing one
-            await updateOwnedIngredient(ingredientId, numericQuantity);
+            const existingQuantity: number = Number(existingIngredient.quantity);
+            await updateOwnedIngredient(ingredientId, existingQuantity + numericQuantity);
             const updatedIngredient = await getOwnedIngredientById(ingredientId);
             res.status(200).json({ 
                 message: 'Ingredient quantity updated', 

--- a/backend/tests/controllers/ownedIngredient.test.ts
+++ b/backend/tests/controllers/ownedIngredient.test.ts
@@ -30,7 +30,7 @@ describe('OwnedIngredient Controller', () => {
         expect(OwnedIngredient.findAll).toHaveBeenCalledWith({
             include: [{
                 model: Ingredient,
-                as: "ingredient",
+                as: 'ingredient',
                 attributes: ['name', 'description', 'standard_unit', 'density']
             }]
         });
@@ -45,7 +45,7 @@ describe('OwnedIngredient Controller', () => {
         expect(OwnedIngredient.findByPk).toHaveBeenCalledWith(1, {
             include: [{
                 model: Ingredient,
-                as: "ingredient",
+                as: 'ingredient',
                 attributes: ['name', 'description', 'standard_unit', 'density']
             }]
         });

--- a/backend/tests/controllers/ownedIngredient.test.ts
+++ b/backend/tests/controllers/ownedIngredient.test.ts
@@ -30,6 +30,7 @@ describe('OwnedIngredient Controller', () => {
         expect(OwnedIngredient.findAll).toHaveBeenCalledWith({
             include: [{
                 model: Ingredient,
+                as: "ingredient",
                 attributes: ['name', 'description', 'standard_unit', 'density']
             }]
         });
@@ -44,6 +45,7 @@ describe('OwnedIngredient Controller', () => {
         expect(OwnedIngredient.findByPk).toHaveBeenCalledWith(1, {
             include: [{
                 model: Ingredient,
+                as: "ingredient",
                 attributes: ['name', 'description', 'standard_unit', 'density']
             }]
         });

--- a/backend/tests/routes/ownedIngredient.test.ts
+++ b/backend/tests/routes/ownedIngredient.test.ts
@@ -1,0 +1,152 @@
+import { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import express from 'express';
+import ownedIngredientsRouter from '../../src/routes/ownedIngredients';
+import * as ownedIngredientController from '../../src/controllers/ownedIngredient';
+
+// Mock the controller functions
+jest.mock('../../src/controllers/ownedIngredient');
+
+const app = express();
+app.use(express.json());
+app.use('/owned-ingredients', ownedIngredientsRouter);
+
+describe('Owned Ingredients Routes', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('GET /', () => {
+        it('should return all owned ingredients', async () => {
+            const mockIngredients = [
+                { ingredientId: 1, quantity: 5 },
+                { ingredientId: 2, quantity: 3 }
+            ];
+            (ownedIngredientController.getOwnedIngredients as jest.Mock).mockResolvedValue(mockIngredients);
+
+            const response = await request(app).get('/owned-ingredients');
+            
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual(mockIngredients);
+            expect(ownedIngredientController.getOwnedIngredients).toHaveBeenCalledTimes(1);
+        });
+
+        it('should handle errors', async () => {
+            const error = new Error('Database error');
+            (ownedIngredientController.getOwnedIngredients as jest.Mock).mockRejectedValue(error);
+
+            const response = await request(app).get('/owned-ingredients');
+            
+            expect(response.status).toBe(500);
+        });
+    });
+
+    describe('POST /', () => {
+        it('should create a new owned ingredient', async () => {
+            const newIngredient = { ingredientId: 1, quantity: 5 };
+            (ownedIngredientController.getOwnedIngredientById as jest.Mock).mockResolvedValue(null);
+            (ownedIngredientController.createOwnedIngredient as jest.Mock).mockResolvedValue(newIngredient);
+
+            const response = await request(app)
+                .post('/owned-ingredients')
+                .send(newIngredient);
+            
+            expect(response.status).toBe(201);
+            expect(response.body).toEqual(newIngredient);
+            expect(ownedIngredientController.createOwnedIngredient).toHaveBeenCalledWith(1, 5);
+        });
+
+        it('should update existing ingredient quantity', async () => {
+            const existingIngredient = { ingredientId: 1, quantity: 5 };
+            const updatedQuantity = 8;
+            (ownedIngredientController.getOwnedIngredientById as jest.Mock).mockResolvedValue(existingIngredient);
+            (ownedIngredientController.updateOwnedIngredient as jest.Mock).mockResolvedValue({ ...existingIngredient, quantity: updatedQuantity });
+
+            const response = await request(app)
+                .post('/owned-ingredients')
+                .send({ ingredientId: 1, quantity: 3 });
+            
+            expect(response.status).toBe(200);
+            expect(response.body.message).toBe('Ingredient quantity updated');
+            expect(ownedIngredientController.updateOwnedIngredient).toHaveBeenCalledWith(1, 8);
+        });
+
+        it('should return 400 for invalid input', async () => {
+            const response = await request(app)
+                .post('/owned-ingredients')
+                .send({ ingredientId: 1 }); // Missing quantity
+            
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBe('ingredientId and quantity are required');
+        });
+    });
+
+    describe('DELETE /:ingredientId', () => {
+        it('should delete an owned ingredient', async () => {
+            (ownedIngredientController.deleteOwnedIngredient as jest.Mock).mockResolvedValue(true);
+
+            const response = await request(app).delete('/owned-ingredients/1');
+            
+            expect(response.status).toBe(200);
+            expect(response.body.message).toBe('Ingredient deleted successfully');
+            expect(ownedIngredientController.deleteOwnedIngredient).toHaveBeenCalledWith(1);
+        });
+
+        it('should return 400 for invalid ingredient ID', async () => {
+            const response = await request(app).delete('/owned-ingredients/invalid');
+            
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBe('Invalid ingredient ID');
+        });
+    });
+
+    describe('DELETE /:ingredientId/quantity', () => {
+        it('should reduce ingredient quantity', async () => {
+            const existingIngredient = { ingredientId: 1, quantity: 10 };
+            (ownedIngredientController.getOwnedIngredientById as jest.Mock).mockResolvedValue(existingIngredient);
+            (ownedIngredientController.updateOwnedIngredient as jest.Mock).mockResolvedValue({ ...existingIngredient, quantity: 7 });
+
+            const response = await request(app)
+                .delete('/owned-ingredients/1/quantity')
+                .send({ quantity: 3 });
+            
+            expect(response.status).toBe(200);
+            expect(response.body.message).toBe('Ingredient quantity updated');
+            expect(response.body.newQuantity).toBe(7);
+        });
+
+        it('should delete ingredient when quantity becomes 0', async () => {
+            const existingIngredient = { ingredientId: 1, quantity: 5 };
+            (ownedIngredientController.getOwnedIngredientById as jest.Mock).mockResolvedValue(existingIngredient);
+            (ownedIngredientController.deleteOwnedIngredient as jest.Mock).mockResolvedValue(true);
+
+            const response = await request(app)
+                .delete('/owned-ingredients/1/quantity')
+                .send({ quantity: 5 });
+            
+            expect(response.status).toBe(200);
+            expect(response.body.message).toBe('Ingredient deleted completely');
+            expect(ownedIngredientController.deleteOwnedIngredient).toHaveBeenCalledWith(1);
+        });
+
+        it('should return 404 for non-existent ingredient', async () => {
+            (ownedIngredientController.getOwnedIngredientById as jest.Mock).mockResolvedValue(null);
+
+            const response = await request(app)
+                .delete('/owned-ingredients/999/quantity')
+                .send({ quantity: 1 });
+            
+            expect(response.status).toBe(404);
+            expect(response.body.error).toBe('Ingredient not found');
+        });
+
+        it('should return 400 for invalid quantity', async () => {
+            const response = await request(app)
+                .delete('/owned-ingredients/1/quantity')
+                .send({ quantity: -1 });
+            
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBe('Valid quantity is required');
+        });
+    });
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

- Added endpoints for getting, creating, and deleting owned ingredients
    - creating adds to the original quantity if it was already owned
    - deleting can either delete the entire owned ingredient or delete some amount of it
- Added tests

## Related Issue

resolves #42

## Motivation and Context

Need endpoints for the pantry

## How Has This Been Tested?

 - tested using 
     - curl -X GET http://localhost:3001/ownedIngredients
     - curl -X POST http://localhost:3001/ownedIngredients -H "Content-Type: application/json" -d '{"ingredientId": 1, "quantity": 3000}'
     - curl -X DELETE http://localhost:3001/ownedIngredients/1
     - curl -X DELETE http://localhost:3001/ownedIngredients/1/quantity -H "Content-Type: application/json" -d '{"quantity": 1}'
     - curl -X DELETE http://localhost:3001/ownedIngredients/1/quantity -H "Content-Type: application/json" -d '{"quantity": 12000}'
 - also used automated tests

## Screenshots (if appropriate):
