### PR TITLE
add link

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -22,7 +22,7 @@ const HomePage: React.FC = () => {
                 <Link to="/pantry/create">add ingredient</Link>
               </Button>
               <Button color="primary" variant="contained" className="min-w-[240px] !text-lg py-3">
-                <Link to="#">see ingredients</Link>
+                <Link to="/pantry">see ingredients</Link>
               </Button>
               <Button color="primary" variant="contained" className="min-w-[240px] !text-lg py-3">
                 <Link to="/aggregate">aggregate recipes</Link>

--- a/frontend/src/pages/pantry/PantryForm.tsx
+++ b/frontend/src/pages/pantry/PantryForm.tsx
@@ -223,10 +223,11 @@ const PantryForm = () => {
             </FormControl>
 
             <TextField
-              label="Density"
+              label="Density (g/cm³)"
               type="number"
               fullWidth
               margin="normal"
+              inputProps={{ step: "0.01" }}
               {...register("density", { valueAsNumber: true, required: true })}
             />
           </>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Makes the see ingredients button on the homepage actually work by linking it to the pantry view. Also, makes it so we can put decimals into density when creating ingredients and specifying g/cm^3.

## Related Issue

None

## Motivation and Context

Forgot to check in the pantry PR.

## How Has This Been Tested?

Clicked on it and it worked

## Screenshots (if appropriate):
