### PR TITLE
Chore/form ingredient and unit required

### DIFF
--- a/backend/db_setup_scripts/seed/seedData.ts
+++ b/backend/db_setup_scripts/seed/seedData.ts
@@ -24,20 +24,48 @@ const unitMapping: { [key: string]: number } = {
     'unit': 20
 };
 
+// Common ingredients that will be inserted first
+export const commonIngredients = [
+    { name: 'All-purpose flour', description: 'Basic flour for baking and cooking', standardUnit: unitMapping['cup'], density: 0.59 },
+    { name: 'Butter', description: 'Dairy product made from churned cream', standardUnit: unitMapping['cup'], density: 0.911 },
+    { name: 'Granulated sugar', description: 'White refined sugar', standardUnit: unitMapping['cup'], density: 0.85 },
+    { name: 'Brown sugar', description: 'Brown sugar with molasses', standardUnit: unitMapping['cup'], density: 0.93 },
+    { name: 'Eggs', description: 'Chicken eggs, a versatile ingredient', standardUnit: unitMapping['unit'] },
+    { name: 'Vanilla extract', description: 'Concentrated vanilla flavoring', standardUnit: unitMapping['tsp'], density: 0.88 },
+    { name: 'Baking soda', description: 'Leavening agent for baking', standardUnit: unitMapping['tsp'], density: 2.2 },
+    { name: 'Salt', description: 'Basic seasoning for enhancing flavors', standardUnit: unitMapping['tsp'], density: 2.16 },
+    { name: 'Chocolate chips', description: 'Small pieces of chocolate for baking', standardUnit: unitMapping['cup'], density: 0.9 },
+    { name: 'Salmon fillet', description: 'Fresh salmon cut into fillets', standardUnit: unitMapping['lb'] },
+    { name: 'Olive oil', description: 'Oil pressed from olives, used for cooking and dressing', standardUnit: unitMapping['tbsp'], density: 0.92 },
+    { name: 'Lemon', description: 'Citrus fruit with sour juice', standardUnit: unitMapping['unit'] },
+    { name: 'Fresh dill', description: 'Aromatic herb with feathery leaves', standardUnit: unitMapping['cup'] },
+    { name: 'Garlic', description: 'Aromatic bulb used for flavoring', standardUnit: unitMapping['unit'] },
+    { name: 'Black pepper', description: 'Ground black peppercorns for seasoning', standardUnit: unitMapping['tsp'], density: 0.4 },
+    { name: 'Broccoli', description: 'Green vegetable with dense clusters of flower buds', standardUnit: unitMapping['cup'] },
+    { name: 'Bell peppers', description: 'Sweet, bell-shaped peppers in various colors', standardUnit: unitMapping['unit'] },
+    { name: 'Carrots', description: 'Root vegetable with a sweet taste', standardUnit: unitMapping['unit'] },
+    { name: 'Snap peas', description: 'Sweet, crisp pea pods', standardUnit: unitMapping['cup'] },
+    { name: 'Soy sauce', description: 'Salty, umami-rich Asian condiment', standardUnit: unitMapping['tbsp'], density: 1.2 },
+    { name: 'Sesame oil', description: 'Oil pressed from sesame seeds', standardUnit: unitMapping['tbsp'], density: 0.92 },
+    { name: 'Ginger', description: 'Aromatic root with spicy flavor', standardUnit: unitMapping['tbsp'] }      
+];
+
+// Sample recipes that will be inserted after ingredients
+// Note: ingredientId values will be replaced with actual IDs after ingredients are inserted
 export const sampleRecipes: RecipeFormData[] = [
     {
         name: 'Classic Chocolate Chip Cookies',
         description: 'Soft and chewy chocolate chip cookies with a crispy edge',
         ingredients: [
-            { name: 'All-purpose flour', quantity: 2.25, unit: unitMapping['cup'] },
-            { name: 'Butter', quantity: 1, unit: unitMapping['cup'] },
-            { name: 'Granulated sugar', quantity: 0.75, unit: unitMapping['cup'] },
-            { name: 'Brown sugar', quantity: 0.75, unit: unitMapping['cup'] },
-            { name: 'Eggs', quantity: 2, unit: unitMapping['unit'] },
-            { name: 'Vanilla extract', quantity: 1, unit: unitMapping['tsp'] },
-            { name: 'Baking soda', quantity: 1, unit: unitMapping['tsp'] },
-            { name: 'Salt', quantity: 0.5, unit: unitMapping['tsp'] },
-            { name: 'Chocolate chips', quantity: 2, unit: unitMapping['cup'] }
+            { ingredientId: 1, quantity: 2.25, unitId: unitMapping['cup'] }, // All-purpose flour
+            { ingredientId: 2, quantity: 1, unitId: unitMapping['cup'] }, // Butter
+            { ingredientId: 3, quantity: 0.75, unitId: unitMapping['cup'] }, // Granulated sugar
+            { ingredientId: 4, quantity: 0.75, unitId: unitMapping['cup'] }, // Brown sugar
+            { ingredientId: 5, quantity: 2, unitId: unitMapping['unit'] }, // Eggs
+            { ingredientId: 6, quantity: 1, unitId: unitMapping['tsp'] }, // Vanilla extract
+            { ingredientId: 7, quantity: 1, unitId: unitMapping['tsp'] }, // Baking soda
+            { ingredientId: 8, quantity: 0.5, unitId: unitMapping['tsp'] }, // Salt
+            { ingredientId: 9, quantity: 2, unitId: unitMapping['cup'] } // Chocolate chips
         ],
         steps: [
             { stepNumber: 1, stepText: 'Preheat oven to 375°F (190°C)' },
@@ -53,13 +81,13 @@ export const sampleRecipes: RecipeFormData[] = [
         name: 'Oven Baked Salmon',
         description: 'Simple and delicious oven-baked salmon with herbs',
         ingredients: [
-            { name: 'Salmon fillet', quantity: 1.5, unit: unitMapping['lb'] },
-            { name: 'Olive oil', quantity: 2, unit: unitMapping['tbsp'] },
-            { name: 'Lemon', quantity: 1, unit: unitMapping['unit'] },
-            { name: 'Fresh dill', quantity: 0.25, unit: unitMapping['cup'] },
-            { name: 'Garlic', quantity: 3, unit: unitMapping['unit'] },
-            { name: 'Salt', quantity: 0.5, unit: unitMapping['tsp'] },
-            { name: 'Black pepper', quantity: 0.25, unit: unitMapping['tsp'] }
+            { ingredientId: 10, quantity: 1.5, unitId: unitMapping['lb'] }, // Salmon fillet
+            { ingredientId: 11, quantity: 2, unitId: unitMapping['tbsp'] }, // Olive oil
+            { ingredientId: 12, quantity: 1, unitId: unitMapping['unit'] }, // Lemon
+            { ingredientId: 13, quantity: 0.25, unitId: unitMapping['cup'] }, // Fresh dill
+            { ingredientId: 14, quantity: 3, unitId: unitMapping['unit'] }, // Garlic
+            { ingredientId: 8, quantity: 0.5, unitId: unitMapping['tsp'] }, // Salt
+            { ingredientId: 15, quantity: 0.25, unitId: unitMapping['tsp'] } // Black pepper
         ],
         steps: [
             { stepNumber: 1, stepText: 'Preheat oven to 400°F (200°C)' },
@@ -73,14 +101,14 @@ export const sampleRecipes: RecipeFormData[] = [
         name: 'Vegetable Stir Fry',
         description: 'Quick and healthy vegetable stir fry with Asian flavors',
         ingredients: [
-            { name: 'Broccoli', quantity: 2, unit: unitMapping['cup'] },
-            { name: 'Bell peppers', quantity: 2, unit: unitMapping['unit'] },
-            { name: 'Carrots', quantity: 2, unit: unitMapping['unit'] },
-            { name: 'Snap peas', quantity: 1, unit: unitMapping['cup'] },
-            { name: 'Soy sauce', quantity: 3, unit: unitMapping['tbsp'] },
-            { name: 'Sesame oil', quantity: 1, unit: unitMapping['tbsp'] },
-            { name: 'Ginger', quantity: 1, unit: unitMapping['tbsp'] },
-            { name: 'Garlic', quantity: 2, unit: unitMapping['unit'] }
+            { ingredientId: 16, quantity: 2, unitId: unitMapping['cup'] }, // Broccoli
+            { ingredientId: 17, quantity: 2, unitId: unitMapping['unit'] }, // Bell peppers
+            { ingredientId: 18, quantity: 2, unitId: unitMapping['unit'] }, // Carrots
+            { ingredientId: 19, quantity: 1, unitId: unitMapping['cup'] }, // Snap peas
+            { ingredientId: 20, quantity: 3, unitId: unitMapping['tbsp'] }, // Soy sauce
+            { ingredientId: 21, quantity: 1, unitId: unitMapping['tbsp'] }, // Sesame oil
+            { ingredientId: 22, quantity: 1, unitId: unitMapping['tbsp'] }, // Ginger
+            { ingredientId: 14, quantity: 2, unitId: unitMapping['unit'] } // Garlic
         ],
         steps: [
             { stepNumber: 1, stepText: 'Cut all vegetables into bite-sized pieces' },
@@ -91,22 +119,4 @@ export const sampleRecipes: RecipeFormData[] = [
             { stepNumber: 6, stepText: 'Pour in soy sauce and stir-fry for 1 more minute' }
         ]
     }
-];
-
-export const commonIngredients = [
-    { name: 'All-purpose flour', description: 'Basic flour for baking and cooking' },
-    { name: 'Butter', description: 'Dairy product made from churned cream' },
-    { name: 'Eggs', description: 'Chicken eggs, a versatile ingredient' },
-    { name: 'Salt', description: 'Basic seasoning for enhancing flavors' },
-    { name: 'Black pepper', description: 'Ground black peppercorns for seasoning' },
-    { name: 'Olive oil', description: 'Oil pressed from olives, used for cooking and dressing' },
-    { name: 'Garlic', description: 'Aromatic bulb used for flavoring' },
-    { name: 'Onion', description: 'Bulb vegetable with a strong, pungent flavor' },
-    { name: 'Rice', description: 'Staple grain used in many cuisines' },
-    { name: 'Chicken', description: 'Poultry meat used in various dishes' },
-    { name: 'Tomatoes', description: 'Fruit used as a vegetable in cooking' },
-    { name: 'Potatoes', description: 'Starchy tuber used in many dishes' },
-    { name: 'Carrots', description: 'Root vegetable with a sweet taste' },
-    { name: 'Bell peppers', description: 'Sweet, bell-shaped peppers in various colors' },
-    { name: 'Broccoli', description: 'Green vegetable with dense clusters of flower buds' }
 ]; 

--- a/backend/db_setup_scripts/seed/seedDatabase.ts
+++ b/backend/db_setup_scripts/seed/seedDatabase.ts
@@ -26,7 +26,12 @@ async function seedIngredients() {
     console.log('Seeding ingredients...');
   
     for (const ingredient of commonIngredients) {
-        await createIngredient(ingredient.name, ingredient.description);
+        await createIngredient(
+            ingredient.name, 
+            ingredient.description,
+            ingredient.standardUnit,
+            ingredient.density
+        );
     }
   
     console.log(`Added ${commonIngredients.length} common ingredients`);
@@ -36,19 +41,17 @@ async function seedRecipes() {
     console.log('Seeding recipes...');
   
     for (const recipeData of sampleRecipes) {
-    // Create the recipe
+        // Create the recipe
         const recipe = await createRecipe(recipeData.name, recipeData.description);
         console.log(`Created recipe: ${recipe.name}`);
     
         // Add ingredients to the recipe
         for (const ingredientData of recipeData.ingredients) {
-            const existingIngredient = await createIngredient(ingredientData.name, '');
-      
             await addIngredientToRecipe(
                 recipe.id,
-                existingIngredient.id,
+                ingredientData.ingredientId,
                 ingredientData.quantity,
-                ingredientData.unit
+                ingredientData.unitId
             );
         }
     

--- a/backend/src/controllers/recipe.ts
+++ b/backend/src/controllers/recipe.ts
@@ -1,6 +1,4 @@
 import { Recipe, Ingredient, Step, RecipeIngredient, RecipeStep, Unit } from '../models/init-models';
-import { getIngredientByName, createIngredient } from './ingredient';
-import { getUnitByName, createUnit } from './unit';
 
 /**
  * Get all recipes (basic data)

--- a/backend/src/controllers/recipe.ts
+++ b/backend/src/controllers/recipe.ts
@@ -24,12 +24,12 @@ export const getRecipeById = async (id: number): Promise<Recipe | null> => {
                     {
                         model: Ingredient,
                         as: 'ingredient',
-                        attributes: ['name'],
+                        attributes: ['id', 'name'],
                     },
                     {
                         model: Unit,
                         as: 'unit',
-                        attributes: ['name'],
+                        attributes: ['id', 'name'],
                     },
                 ],
                 attributes: ['quantity'],
@@ -101,9 +101,11 @@ export const updateRecipeWithRelations = async (
     recipeIngredients?: Array<{
         quantity: string;
         ingredient: {
+            id: number;
             name: string;
         };
         unit: {
+            id: number;
             name: string;
         };
     }>,
@@ -141,24 +143,12 @@ export const updateRecipeWithRelations = async (
 
             // Create new recipe ingredients
             for (const ing of recipeIngredients) {
-                // Find or create ingredient
-                let ingredient = await getIngredientByName(ing.ingredient.name);
-                if (!ingredient) {
-                    ingredient = await createIngredient(ing.ingredient.name);
-                }
-
-                // Find or create unit
-                let unit = await getUnitByName(ing.unit.name);
-                if (!unit) {
-                    unit = await createUnit(ing.unit.name, 'other'); // Default type
-                }
-
-                // Create recipe ingredient
+                // Create recipe ingredient with the provided IDs
                 await RecipeIngredient.create({
                     recipeId: id,
-                    ingredientId: ingredient.id,
+                    ingredientId: ing.ingredient.id,
                     quantity: parseFloat(ing.quantity),
-                    unitId: unit.id,
+                    unitId: ing.unit.id,
                 }, { transaction });
             }
         }

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -62,26 +62,14 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
         // Create the base recipe
         const recipe = await createRecipe(recipeData.name, recipeData.description);
 
-        // Create ingredients and associate with recipe
+        // Associate ingredients with recipe
         await Promise.all(
             recipeData.ingredients.map(async (ingredientData) => {
-                const ingredient = await createIngredient(
-                    ingredientData.name,
-                    '', // description
-                    undefined,
-                    undefined
-                );
-
-                const unitRecord = await getUnitByName(ingredientData.unit);
-                if (!unitRecord) {
-                    throw new Error(`Unit "${ingredientData.unit}" not found.`);
-                }
-
                 await addIngredientToRecipe(
                     recipe.id,
-                    ingredient.id,
+                    ingredientData.ingredientId,
                     ingredientData.quantity,
-                    unitRecord.id
+                    ingredientData.unitId
                 );
             })
         );

--- a/backend/src/routes/recipes.ts
+++ b/backend/src/routes/recipes.ts
@@ -5,12 +5,9 @@ import {
     createRecipe, 
     deleteRecipe,
     updateRecipeWithRelations,
-    createIngredient,
-    getUnitByName,
     createStep,
     addIngredientToRecipe,
     addStepToRecipe,
-    getUnitById,
 } from '../controllers';
 import { Recipe } from '../models/recipe';
 import { RecipeFormData } from '../types/recipeFormData';

--- a/backend/src/types/recipeFormData.ts
+++ b/backend/src/types/recipeFormData.ts
@@ -1,6 +1,6 @@
 export type RecipeFormData = {
     name: string;
     description: string;
-    ingredients: { name: string; quantity: number; unit: string }[];
+    ingredients: { ingredientId: number; quantity: number; unitId: number }[];
     steps: { stepNumber: number; stepText: string }[];
 };

--- a/backend/tests/controllers/recipe.test.ts
+++ b/backend/tests/controllers/recipe.test.ts
@@ -48,8 +48,8 @@ describe('Recipe Controller', () => {
                     model: RecipeIngredient,
                     as: 'recipeIngredients',
                     include: [
-                        { model: Ingredient, as: 'ingredient', attributes: ['name'] },
-                        { model: Unit, as: 'unit', attributes: ['name'] },
+                        { model: Ingredient, as: 'ingredient', attributes: ['id', 'name'] },
+                        { model: Unit, as: 'unit', attributes: ['id', 'name'] },
                     ],
                     attributes: ['quantity'],
                 },

--- a/backend/tests/routes/ingredients.test.ts
+++ b/backend/tests/routes/ingredients.test.ts
@@ -1,6 +1,4 @@
 import request from 'supertest';
-import express from 'express';
-import ingredientRouter from '../../src/routes/ingredients';
 import * as ingredientController from '../../src/controllers/ingredient';
 import app from '../../src/app';
 

--- a/backend/tests/routes/recipes.test.ts
+++ b/backend/tests/routes/recipes.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import app from '../../src/app';
-import { addIngredientToRecipe, addStepToRecipe, createIngredient, createRecipe, createStep, deleteRecipe, getRecipeById, getRecipes, getUnitById, updateRecipeWithRelations } from '../../src/controllers';
+import { addIngredientToRecipe, addStepToRecipe, createRecipe, createStep, deleteRecipe, getRecipeById, getRecipes, updateRecipeWithRelations } from '../../src/controllers';
 
 // Mock all controller functions
 jest.mock('../../src/controllers');

--- a/backend/tests/routes/recipes.test.ts
+++ b/backend/tests/routes/recipes.test.ts
@@ -77,8 +77,8 @@ describe('Recipes Routes', () => {
                 name: 'Test Recipe',
                 description: 'Test Description',
                 ingredients: [
-                    { name: 'Ingredient 1', unit: 'cup', quantity: 2 },
-                    { name: 'Ingredient 2', unit: 'tbsp', quantity: 1 }
+                    { ingredientId: 1, unitId: 1, quantity: 2 },
+                    { ingredientId: 2, unitId: 2, quantity: 1 }
                 ],
                 steps: [
                     { stepNumber: 1, stepText: 'Step 1' },
@@ -92,16 +92,6 @@ describe('Recipes Routes', () => {
                 name: recipeData.name,
                 description: recipeData.description,
                 toJSON: () => ({ id: 1, name: recipeData.name, description: recipeData.description })
-            });
-            (createIngredient as jest.Mock).mockResolvedValue({
-                id: 1,
-                name: 'Ingredient 1',
-                toJSON: () => ({ id: 1, name: 'Ingredient 1' })
-            });
-            (getUnitByName as jest.Mock).mockResolvedValue({
-                id: 1,
-                name: 'cup',
-                toJSON: () => ({ id: 1, name: 'cup' })
             });
             (createStep as jest.Mock).mockResolvedValue({
                 id: 1,
@@ -126,7 +116,7 @@ describe('Recipes Routes', () => {
                 name: 'Test Recipe',
                 description: 'Test Description',
                 ingredients: [
-                    { name: 'Ingredient 1', unit: 'invalid_unit', quantity: 2 }
+                    { ingredientId: 1, unitId: 999, quantity: 2 }
                 ],
                 steps: []
             };
@@ -137,12 +127,7 @@ describe('Recipes Routes', () => {
                 description: recipeData.description,
                 toJSON: () => ({ id: 1, name: recipeData.name, description: recipeData.description })
             });
-            (createIngredient as jest.Mock).mockResolvedValue({
-                id: 1,
-                name: 'Ingredient 1',
-                toJSON: () => ({ id: 1, name: 'Ingredient 1' })
-            });
-            (getUnitByName as jest.Mock).mockResolvedValue(null);
+            (addIngredientToRecipe as jest.Mock).mockRejectedValue(new Error('Unit not found'));
 
             const response = await request(app)
                 .post('/recipes')

--- a/frontend/src/components/IngredientsBox.tsx
+++ b/frontend/src/components/IngredientsBox.tsx
@@ -161,7 +161,13 @@ const IngredientsBox: React.FC<IngredientsBoxProps> = ({ ingredients, setIngredi
     },
     onSuccess: (newIngredient) => {
       queryClient.invalidateQueries({ queryKey: ['ingredients'] });
-      handleIngredientSelect(activeIndex, newIngredient.id);
+      const newIngredients = [...ingredients];
+      if (activeIndex >= 0 && activeIndex < newIngredients.length) {
+        newIngredients[activeIndex].ingredientId = newIngredient.id;
+        setIngredients(newIngredients);
+        setSearchTerm(newIngredient.name);
+      }
+      setShowDropdown(false);
       setShowNewIngredientForm(false);
       setNewIngredient({
         name: '',
@@ -174,6 +180,9 @@ const IngredientsBox: React.FC<IngredientsBoxProps> = ({ ingredients, setIngredi
 
   const handleCreateNewIngredient = () => {
     if (newIngredient.name.trim()) {
+      if (activeIndex === -1 && ingredients.length > 0) {
+        setActiveIndex(ingredients.length - 1);
+      }
       createIngredientMutation.mutate(newIngredient);
     }
   };
@@ -216,7 +225,12 @@ const IngredientsBox: React.FC<IngredientsBoxProps> = ({ ingredients, setIngredi
                   <div className="p-2">
                     <div className="text-gray-500 mb-2">No ingredients found</div>
                     <button
-                      onClick={() => setShowNewIngredientForm(true)}
+                      onClick={() => {
+                        setShowNewIngredientForm(true);
+                        if (activeIndex === -1 && ingredients.length > 0) {
+                          setActiveIndex(ingredients.length - 1);
+                        }
+                      }}
                       className="text-blue-500 hover:text-blue-700"
                     >
                       Create new ingredient

--- a/frontend/src/components/IngredientsBox.tsx
+++ b/frontend/src/components/IngredientsBox.tsx
@@ -126,6 +126,19 @@ const IngredientsBox: React.FC<IngredientsBoxProps> = ({ ingredients, setIngredi
           }
         }, 0);
       }
+    } else if (e.key === 'Backspace' && !ingredients[index].ingredientId && index > 0) {
+      e.preventDefault();
+      const newIngredients = ingredients.filter((_, i) => i !== index);
+      setIngredients(newIngredients);
+      setSearchTerm('');
+      setShowDropdown(false);
+      setActiveIndex(-1);
+      setTimeout(() => {
+        const inputs = document.querySelectorAll('.ingredient-input');
+        if (inputs.length > 0) {
+          (inputs[index - 1] as HTMLInputElement).focus();
+        }
+      }, 0);
     }
   };
 

--- a/frontend/src/components/IngredientsBox.tsx
+++ b/frontend/src/components/IngredientsBox.tsx
@@ -178,11 +178,6 @@ const IngredientsBox: React.FC<IngredientsBoxProps> = ({ ingredients, setIngredi
     }
   };
 
-  const isVolumeUnit = (unitId: number) => {
-    const unit = units?.find(u => u.id === unitId);
-    return unit?.type === 'volume';
-  };
-
   const getCompatibleUnits = (standardUnitId: number, hasDensity: boolean) => {
     if (!units) return [];
     

--- a/frontend/src/components/IngredientsBox.tsx
+++ b/frontend/src/components/IngredientsBox.tsx
@@ -118,6 +118,7 @@ const IngredientsBox: React.FC<IngredientsBoxProps> = ({ ingredients, setIngredi
         setIngredients([...ingredients, { ingredientId: 0, quantity: 0, unitId: 0 }]);
         setSearchTerm('');
         setShowDropdown(false);
+        setActiveIndex(-1);
         setTimeout(() => {
           const inputs = document.querySelectorAll('.ingredient-input');
           if (inputs.length > 0) {

--- a/frontend/src/components/IngredientsBox.tsx
+++ b/frontend/src/components/IngredientsBox.tsx
@@ -1,0 +1,185 @@
+import React, { useState, KeyboardEvent } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+interface Unit {
+  id: number;
+  name: string;
+  type: string;
+}
+
+interface Ingredient {
+  id: number;
+  name: string;
+  description?: string;
+  standardUnit?: number;
+  density?: number;
+}
+
+interface IngredientEntry {
+  ingredientId: number;
+  quantity: number;
+  unitId: number;
+}
+
+interface IngredientsBoxProps {
+  ingredients: IngredientEntry[];
+  setIngredients: (ings: IngredientEntry[]) => void;
+  API_BASE: string;
+}
+
+const IngredientsBox: React.FC<IngredientsBoxProps> = ({ ingredients, setIngredients, API_BASE }) => {
+  const fetchUnits = async (): Promise<Unit[]> => {
+    const response = await fetch(`${API_BASE}/units`);
+    if (!response.ok) {
+      throw new Error('Failed to fetch units');
+    }
+    return response.json();
+  };
+
+  const fetchIngredients = async (): Promise<Ingredient[]> => {
+    const response = await fetch(`${API_BASE}/ingredients`);
+    if (!response.ok) {
+      throw new Error('Failed to fetch ingredients');
+    }
+    return response.json();
+  };
+
+  const { data: units, isLoading: unitsLoading, error: unitsError } = useQuery<Unit[]>({
+    queryKey: ['units'],
+    queryFn: fetchUnits,
+  });
+
+  const { data: availableIngredients, isLoading: ingredientsLoading, error: ingredientsError } = useQuery<Ingredient[]>({
+    queryKey: ['ingredients'],
+    queryFn: fetchIngredients,
+  });
+
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [showDropdown, setShowDropdown] = useState<boolean>(false);
+  const [activeIndex, setActiveIndex] = useState<number>(-1);
+
+  const filteredIngredients = availableIngredients?.filter(ing => 
+    ing.name.toLowerCase().includes(searchTerm.toLowerCase())
+  ) || [];
+
+  const getIngredientName = (ingredientId: number) => {
+    return availableIngredients?.find(i => i.id === ingredientId)?.name || '';
+  };
+
+  const handleIngredientSearch = (index: number, value: string) => {
+    setSearchTerm(value);
+    setShowDropdown(true);
+    setActiveIndex(index);
+  };
+
+  const handleIngredientSelect = (index: number, ingredientId: number) => {
+    const newIngredients = [...ingredients];
+    newIngredients[index].ingredientId = ingredientId;
+    setIngredients(newIngredients);
+    setSearchTerm(getIngredientName(ingredientId));
+    setShowDropdown(false);
+  };
+
+  const handleQuantityChange = (index: number, value: string) => {
+    const newIngredients = [...ingredients];
+    const numericValue = Number(value);
+    if (!isNaN(numericValue)) {
+      newIngredients[index].quantity = numericValue;
+    }
+    setIngredients(newIngredients);
+  };
+
+  const handleUnitChange = (index: number, value: string) => {
+    const newIngredients = [...ingredients];
+    newIngredients[index].unitId = Number(value);
+    setIngredients(newIngredients);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>, index: number) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (ingredients[index].ingredientId) {
+        setIngredients([...ingredients, { ingredientId: 0, quantity: 0, unitId: 0 }]);
+        setSearchTerm('');
+        setShowDropdown(false);
+        setTimeout(() => {
+          const inputs = document.querySelectorAll('.ingredient-input');
+          if (inputs.length > 0) {
+            (inputs[inputs.length - 1] as HTMLInputElement).focus();
+          }
+        }, 0);
+      }
+    }
+  };
+
+  return (
+    <div className="relative bg-white rounded-lg shadow-lg p-4 mt-6 w-1/2 min-h-[70vh]">
+      <h2 className="text-xl font-bold mb-4">Ingredients</h2>
+      {ingredients.map((ingredient, index) => (
+        <div key={index} className="flex items-center mb-2">
+          <span className="mr-2 font-semibold">{index + 1}.)</span>
+          <div className="relative flex-1">
+            <input
+              type="text"
+              placeholder="Search ingredient..."
+              value={activeIndex === index ? searchTerm : getIngredientName(ingredient.ingredientId)}
+              onChange={(e) => handleIngredientSearch(index, e.target.value)}
+              onKeyDown={(e) => handleKeyDown(e, index)}
+              className="w-full p-2 rounded focus:outline-none ingredient-input"
+            />
+            {showDropdown && activeIndex === index && (
+              <div className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded shadow-lg max-h-60 overflow-auto">
+                {ingredientsLoading ? (
+                  <div className="p-2">Loading ingredients...</div>
+                ) : ingredientsError ? (
+                  <div className="p-2">Error loading ingredients</div>
+                ) : filteredIngredients.length === 0 ? (
+                  <div className="p-2">No ingredients found</div>
+                ) : (
+                  filteredIngredients.map((ing) => (
+                    <div
+                      key={ing.id}
+                      className="p-2 hover:bg-gray-100 cursor-pointer"
+                      onClick={() => handleIngredientSelect(index, ing.id)}
+                    >
+                      {ing.name}
+                    </div>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
+          <div className="flex items-center ml-2 border border-black rounded p-1">
+            <input
+              type="text"
+              placeholder="0"
+              value={ingredient.quantity === 0 ? '' : ingredient.quantity}
+              onChange={(e) => handleQuantityChange(index, e.target.value)}
+              className="w-12 p-1 outline-none"
+            />
+            <select
+              value={ingredient.unitId || 0}
+              onChange={(e) => handleUnitChange(index, e.target.value)}
+              className="p-1 outline-none"
+            >
+              <option value={0}>Select unit...</option>
+              {unitsLoading ? (
+                <option>Loading units...</option>
+              ) : unitsError ? (
+                <option>Error loading units</option>
+              ) : (
+                units?.map((unit) => (
+                  <option key={unit.id} value={unit.id}>
+                    {unit.name}
+                  </option>
+                ))
+              )}
+            </select>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default IngredientsBox; 

--- a/frontend/src/components/InstructionsBox.tsx
+++ b/frontend/src/components/InstructionsBox.tsx
@@ -1,0 +1,51 @@
+import React, { KeyboardEvent } from 'react';
+
+interface InstructionsBoxProps {
+  instructions: string[];
+  setInstructions: (ins: string[]) => void;
+}
+
+const InstructionsBox: React.FC<InstructionsBoxProps> = ({ instructions, setInstructions }) => {
+  const handleInputChange = (index: number, value: string) => {
+    const newInstructions = [...instructions];
+    newInstructions[index] = value;
+    setInstructions(newInstructions);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>, index: number) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (instructions[index].trim() !== '') {
+        setInstructions([...instructions, '']);
+        // Focus the new input after state update
+        setTimeout(() => {
+          const inputs = document.querySelectorAll('.instruction-input');
+          if (inputs.length > 0) {
+            (inputs[inputs.length - 1] as HTMLInputElement).focus();
+          }
+        }, 0);
+      }
+    }
+  };
+
+  return (
+    <div className="relative p-4 mt-6 w-1/2">
+      <h2 className="text-xl font-bold mb-4">Instructions</h2>
+      {instructions.map((step, index) => (
+        <div key={index} className="flex items-center mb-2">
+          <span className="mr-2 font-semibold">{index + 1}.)</span>
+          <input
+            type="text"
+            placeholder="add step..."
+            value={step}
+            onChange={(e) => handleInputChange(index, e.target.value)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
+            className="flex-1 p-2 rounded focus:outline-none bg-transparent instruction-input"
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default InstructionsBox; 

--- a/frontend/src/components/InstructionsBox.tsx
+++ b/frontend/src/components/InstructionsBox.tsx
@@ -25,6 +25,17 @@ const InstructionsBox: React.FC<InstructionsBoxProps> = ({ instructions, setInst
           }
         }, 0);
       }
+    } else if (e.key === 'Backspace' && instructions[index].trim() === '' && index > 0) {
+      e.preventDefault();
+      const newInstructions = instructions.filter((_, i) => i !== index);
+      setInstructions(newInstructions);
+      // Focus the previous input after state update
+      setTimeout(() => {
+        const inputs = document.querySelectorAll('.instruction-input');
+        if (inputs.length > 0) {
+          (inputs[index - 1] as HTMLInputElement).focus();
+        }
+      }, 0);
     }
   };
 

--- a/frontend/src/components/InstructionsBox.tsx
+++ b/frontend/src/components/InstructionsBox.tsx
@@ -1,16 +1,28 @@
 import React, { KeyboardEvent, useRef, useEffect } from 'react';
 
+interface Step {
+  stepId: number;
+  stepNumber: number;
+  stepText: string;
+}
+
 interface InstructionsBoxProps {
-  instructions: string[];
-  setInstructions: (ins: string[]) => void;
+  instructions: Step[];
+  setInstructions: (ins: Step[]) => void;
 }
 
 const InstructionsBox: React.FC<InstructionsBoxProps> = ({ instructions, setInstructions }) => {
   const textareaRefs = useRef<(HTMLTextAreaElement | null)[]>([]);
 
+  // Sort instructions by step number
+  const sortedInstructions = [...instructions].sort((a, b) => a.stepNumber - b.stepNumber);
+
   const handleInputChange = (index: number, value: string) => {
     const newInstructions = [...instructions];
-    newInstructions[index] = value;
+    const stepToUpdate = newInstructions.find(step => step.stepId === sortedInstructions[index].stepId);
+    if (stepToUpdate) {
+      stepToUpdate.stepText = value;
+    }
     setInstructions(newInstructions);
   };
 
@@ -30,19 +42,48 @@ const InstructionsBox: React.FC<InstructionsBoxProps> = ({ instructions, setInst
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>, index: number) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      if (instructions[index].trim() !== '') {
-        setInstructions([...instructions, '']);
+      if (sortedInstructions[index].stepText.trim() !== '') {
+        // Insert new empty step after the current one
+        const newInstructions = [...instructions];
+        const maxStepId = Math.max(...instructions.map(step => step.stepId), 0);
+        const currentStepNumber = sortedInstructions[index].stepNumber;
+        
+        // Increment step numbers for all steps after the current one
+        newInstructions.forEach(step => {
+          if (step.stepNumber > currentStepNumber) {
+            step.stepNumber += 1;
+          }
+        });
+
+        // Insert new step with the next number
+        newInstructions.push({
+          stepId: maxStepId + 1,
+          stepNumber: currentStepNumber + 1,
+          stepText: ''
+        });
+
+        setInstructions(newInstructions);
         // Focus the new input after state update
         setTimeout(() => {
           const inputs = document.querySelectorAll('.instruction-input');
-          if (inputs.length > 0) {
-            (inputs[inputs.length - 1] as HTMLTextAreaElement).focus();
+          const nextIndex = [...sortedInstructions].findIndex(step => step.stepNumber === currentStepNumber) + 1;
+          if (inputs.length > nextIndex) {
+            (inputs[nextIndex] as HTMLTextAreaElement).focus();
           }
         }, 0);
       }
-    } else if (e.key === 'Backspace' && instructions[index].trim() === '' && index > 0) {
+    } else if (e.key === 'Backspace' && sortedInstructions[index].stepText.trim() === '' && index > 0) {
       e.preventDefault();
-      const newInstructions = instructions.filter((_, i) => i !== index);
+      const stepToDelete = sortedInstructions[index];
+      const newInstructions = instructions.filter(step => step.stepId !== stepToDelete.stepId);
+      
+      // Update step numbers for all steps after the deleted one
+      newInstructions.forEach(step => {
+        if (step.stepNumber > stepToDelete.stepNumber) {
+          step.stepNumber -= 1;
+        }
+      });
+
       setInstructions(newInstructions);
       // Focus the previous input after state update
       setTimeout(() => {
@@ -57,9 +98,9 @@ const InstructionsBox: React.FC<InstructionsBoxProps> = ({ instructions, setInst
   return (
     <div className="relative p-4 mt-6 w-1/2">
       <h2 className="text-xl font-bold mb-4">Instructions</h2>
-      {instructions.map((step, index) => (
-        <div key={index} className="flex items-start mb-2">
-          <span className="mr-2 font-semibold mt-2">{index + 1}.)</span>
+      {sortedInstructions.map((step, index) => (
+        <div key={step.stepId} className="flex items-start mb-2">
+          <span className="mr-2 font-semibold mt-2">{step.stepNumber}.)</span>
           <textarea
             ref={el => {
               if (el) {
@@ -67,14 +108,14 @@ const InstructionsBox: React.FC<InstructionsBoxProps> = ({ instructions, setInst
               }
             }}
             placeholder="add step..."
-            value={step}
+            value={step.stepText}
             onChange={(e) => {
               handleInputChange(index, e.target.value);
               adjustTextareaHeight(e.target);
             }}
             onKeyDown={(e) => handleKeyDown(e, index)}
             className="flex-1 p-2 rounded focus:outline-none bg-transparent instruction-input resize-none overflow-hidden"
-            style={{ minHeight: '2.5rem' }}
+            style={{ minHeight: '2.5rem', marginTop: '0', marginBottom: '0' }}
           />
         </div>
       ))}

--- a/frontend/src/pages/RecipeFormPage.tsx
+++ b/frontend/src/pages/RecipeFormPage.tsx
@@ -70,7 +70,11 @@ const RecipeFormPage: React.FC = () => {
   const [ingredients, setIngredients] = useState<IngredientEntry[]>([
     { ingredientId: 0, quantity: 0, unitId: 0 },
   ]);
-  const [instructions, setInstructions] = useState<string[]>(['']);
+  const [instructions, setInstructions] = useState<Array<{stepId: number; stepNumber: number; stepText: string}>>([{
+    stepId: 1,
+    stepNumber: 1,
+    stepText: ''
+  }]);
   const headerImage = "/Brownie_Header.jpg";
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const navigate = useNavigate();
@@ -92,10 +96,10 @@ const RecipeFormPage: React.FC = () => {
           unitId: ing.unitId
         })),
       steps: instructions
-        .filter(step => step.trim() !== '')
-        .map((stepText, index) => ({
-          stepNumber: index + 1,
-          stepText
+        .filter(step => step.stepText.trim() !== '')
+        .map(step => ({
+          stepNumber: step.stepNumber,
+          stepText: step.stepText
         }))
     };
     mutation.mutate(newRecipe, {

--- a/frontend/src/pages/RecipeFormPage.tsx
+++ b/frontend/src/pages/RecipeFormPage.tsx
@@ -1,8 +1,10 @@
-import React, { useState, KeyboardEvent } from 'react';
+import React, { useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { Box, Button } from '@mui/material';
 import Sidebar from './Sidebar';
 import { useNavigate } from 'react-router-dom';
+import IngredientsBox from '../components/IngredientsBox';
+import InstructionsBox from '../components/InstructionsBox';
 
 interface IngredientEntry {
   ingredientId: number;
@@ -57,179 +59,6 @@ const useSubmitRecipe = () => {
       return response.json();
     },
   });
-};
-
-interface IngredientsBoxProps {
-  ingredients: IngredientEntry[];
-  setIngredients: (ings: IngredientEntry[]) => void;
-}
-
-const IngredientsBox: React.FC<IngredientsBoxProps> = ({ ingredients, setIngredients }) => {
-  const fetchUnits = async (): Promise<Unit[]> => {
-    const response = await fetch(`${API_BASE}/units`);
-    if (!response.ok) {
-      throw new Error('Failed to fetch units');
-    }
-    return response.json();
-  };
-
-  const fetchIngredients = async (): Promise<Ingredient[]> => {
-    const response = await fetch(`${API_BASE}/ingredients`);
-    if (!response.ok) {
-      throw new Error('Failed to fetch ingredients');
-    }
-    return response.json();
-  };
-
-  const { data: units, isLoading: unitsLoading, error: unitsError } = useQuery<Unit[]>({
-    queryKey: ['units'],
-    queryFn: fetchUnits,
-  });
-
-  const { data: availableIngredients, isLoading: ingredientsLoading, error: ingredientsError } = useQuery<Ingredient[]>({
-    queryKey: ['ingredients'],
-    queryFn: fetchIngredients,
-  });
-
-  const handleIngredientChange = (index: number, value: string) => {
-    const newIngredients = [...ingredients];
-    newIngredients[index].ingredientId = Number(value);
-    setIngredients(newIngredients);
-  };
-
-  const handleQuantityChange = (index: number, value: string) => {
-    const newIngredients = [...ingredients];
-    const numericValue = Number(value);
-    if (!isNaN(numericValue)) {
-      newIngredients[index].quantity = numericValue;
-    }
-    setIngredients(newIngredients);
-  };
-
-  const handleUnitChange = (index: number, value: string) => {
-    const newIngredients = [...ingredients];
-    newIngredients[index].unitId = Number(value);
-    setIngredients(newIngredients);
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>, index: number) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      if (ingredients[index].ingredientId) {
-        setIngredients([...ingredients, { ingredientId: 0, quantity: 0, unitId: 0 }]);
-        setTimeout(() => {
-          const inputs = document.querySelectorAll('.ingredient-input');
-          if (inputs.length > 0) {
-            (inputs[inputs.length - 1] as HTMLInputElement).focus();
-          }
-        }, 0);
-      }
-    }
-  };
-
-  return (
-    <div className="relative bg-white rounded-lg shadow-lg p-4 mt-6 w-1/2 min-h-[70vh]">
-      <h2 className="text-xl font-bold mb-4">Ingredients</h2>
-      {ingredients.map((ingredient, index) => (
-        <div key={index} className="flex items-center mb-2">
-          <span className="mr-2 font-semibold">{index + 1}.)</span>
-          <select
-            value={ingredient.ingredientId}
-            onChange={(e) => handleIngredientChange(index, e.target.value)}
-            className="flex-1 p-2 rounded focus:outline-none ingredient-input"
-          >
-            <option value={0}>Select ingredient...</option>
-            {ingredientsLoading ? (
-              <option>Loading ingredients...</option>
-            ) : ingredientsError ? (
-              <option>Error loading ingredients</option>
-            ) : (
-              availableIngredients?.map((ing) => (
-                <option key={ing.id} value={ing.id}>
-                  {ing.name}
-                </option>
-              ))
-            )}
-          </select>
-          <div className="flex items-center ml-2 border border-black rounded p-1">
-            <input
-              type="text"
-              placeholder="0"
-              value={ingredient.quantity === 0 ? '' : ingredient.quantity}
-              onChange={(e) => handleQuantityChange(index, e.target.value)}
-              className="w-12 p-1 outline-none"
-            />
-            <select
-              value={ingredient.unitId}
-              onChange={(e) => handleUnitChange(index, e.target.value)}
-              className="p-1 outline-none"
-            >
-              <option value={0}>Select unit...</option>
-              {unitsLoading ? (
-                <option>Loading units...</option>
-              ) : unitsError ? (
-                <option>Error loading units</option>
-              ) : (
-                units?.map((unit) => (
-                  <option key={unit.id} value={unit.id}>
-                    {unit.name}
-                  </option>
-                ))
-              )}
-            </select>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-};
-
-interface InstructionsBoxProps {
-  instructions: string[];
-  setInstructions: (ins: string[]) => void;
-}
-
-const InstructionsBox: React.FC<InstructionsBoxProps> = ({ instructions, setInstructions }) => {
-  const handleInputChange = (index: number, value: string) => {
-    const newInstructions = [...instructions];
-    newInstructions[index] = value;
-    setInstructions(newInstructions);
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>, index: number) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      if (instructions[index].trim() !== '') {
-        setInstructions([...instructions, '']);
-        // Focus the new input after state update
-        setTimeout(() => {
-          const inputs = document.querySelectorAll('.instruction-input');
-          if (inputs.length > 0) {
-            (inputs[inputs.length - 1] as HTMLInputElement).focus();
-          }
-        }, 0);
-      }
-    }
-  };
-
-  return (
-    <div className="relative p-4 mt-6 w-1/2">
-      <h2 className="text-xl font-bold mb-4">Instructions</h2>
-      {instructions.map((step, index) => (
-        <div key={index} className="flex items-center mb-2">
-          <span className="mr-2 font-semibold">{index + 1}.)</span>
-          <input
-            type="text"
-            placeholder="add step..."
-            value={step}
-            onChange={(e) => handleInputChange(index, e.target.value)}
-            onKeyDown={(e) => handleKeyDown(e, index)}
-            className="flex-1 p-2 rounded focus:outline-none bg-transparent instruction-input"
-          />
-        </div>
-      ))}
-    </div>
-  );
 };
 
 const RecipeFormPage: React.FC = () => {
@@ -333,7 +162,7 @@ const RecipeFormPage: React.FC = () => {
           </span>
         </div>
         <div className="flex flex-row gap-8">
-          <IngredientsBox ingredients={ingredients} setIngredients={setIngredients} />
+          <IngredientsBox ingredients={ingredients} setIngredients={setIngredients} API_BASE={API_BASE} />
           <InstructionsBox instructions={instructions} setInstructions={setInstructions} />
         </div>
         <Box mt={4}>

--- a/frontend/src/pages/RecipeFormPage.tsx
+++ b/frontend/src/pages/RecipeFormPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { Box, Button } from '@mui/material';
 import Sidebar from './Sidebar';
 import { useNavigate } from 'react-router-dom';
@@ -27,20 +27,6 @@ interface CreateRecipeData {
     stepNumber: number;
     stepText: string;
   }[];
-}
-
-interface Unit {
-  id: number;
-  name: string;
-  type: string;
-}
-
-interface Ingredient {
-  id: number;
-  name: string;
-  description?: string;
-  standardUnit?: number;
-  density?: number;
 }
 
 const API_BASE = import.meta.env.VITE_BACKEND_HOST || 'http://localhost:3001';

--- a/frontend/src/pages/RecipeUpdatePage.tsx
+++ b/frontend/src/pages/RecipeUpdatePage.tsx
@@ -1,8 +1,24 @@
-import React, { useState, useEffect, KeyboardEvent } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { Box, Button, Snackbar, Alert } from '@mui/material';
 import Sidebar from './Sidebar';
+import IngredientsBox from '../components/IngredientsBox';
+import InstructionsBox from '../components/InstructionsBox';
+
+interface Unit {
+  id: number;
+  name: string;
+  type: string;
+}
+
+interface Ingredient {
+  id: number;
+  name: string;
+  description?: string;
+  standardUnit?: number;
+  density?: number;
+}
 
 interface IngredientEntry {
   ingredientId: number;
@@ -38,20 +54,6 @@ interface RecipeData {
   }[];
 }
 
-interface Unit {
-  id: number;
-  name: string;
-  type: string;
-}
-
-interface Ingredient {
-  id: number;
-  name: string;
-  description?: string;
-  standardUnit?: number;
-  density?: number;
-}
-
 const API_BASE = import.meta.env.VITE_BACKEND_HOST || 'http://localhost:3001';
 
 const useFetchRecipe = (id: string) => {
@@ -81,214 +83,6 @@ const useUpdateRecipe = () => {
       return response.json();
     },
   });
-};
-
-interface IngredientsBoxProps {
-  ingredients: IngredientEntry[];
-  setIngredients: (ings: IngredientEntry[]) => void;
-}
-
-const IngredientsBox: React.FC<IngredientsBoxProps> = ({ ingredients, setIngredients }) => {
-  const fetchUnits = async (): Promise<Unit[]> => {
-    const response = await fetch(`${API_BASE}/units`);
-    if (!response.ok) {
-      throw new Error('Failed to fetch units');
-    }
-    return response.json();
-  };
-
-  const fetchIngredients = async (): Promise<Ingredient[]> => {
-    const response = await fetch(`${API_BASE}/ingredients`);
-    if (!response.ok) {
-      throw new Error('Failed to fetch ingredients');
-    }
-    return response.json();
-  };
-
-  const { data: units, isLoading: unitsLoading, error: unitsError } = useQuery<Unit[]>({
-    queryKey: ['units'],
-    queryFn: fetchUnits,
-  });
-
-  const { data: availableIngredients, isLoading: ingredientsLoading, error: ingredientsError } = useQuery<Ingredient[]>({
-    queryKey: ['ingredients'],
-    queryFn: fetchIngredients,
-  });
-
-  const [searchTerm, setSearchTerm] = useState<string>('');
-  const [showDropdown, setShowDropdown] = useState<boolean>(false);
-  const [activeIndex, setActiveIndex] = useState<number>(-1);
-
-  const filteredIngredients = availableIngredients?.filter(ing => 
-    ing.name.toLowerCase().includes(searchTerm.toLowerCase())
-  ) || [];
-
-  const getIngredientName = (ingredientId: number) => {
-    return availableIngredients?.find(i => i.id === ingredientId)?.name || '';
-  };
-
-  const handleIngredientSearch = (index: number, value: string) => {
-    setSearchTerm(value);
-    setShowDropdown(true);
-    setActiveIndex(index);
-  };
-
-  const handleIngredientSelect = (index: number, ingredientId: number) => {
-    const newIngredients = [...ingredients];
-    newIngredients[index].ingredientId = ingredientId;
-    setIngredients(newIngredients);
-    setSearchTerm(getIngredientName(ingredientId));
-    setShowDropdown(false);
-  };
-
-  const handleQuantityChange = (index: number, value: string) => {
-    const newIngredients = [...ingredients];
-    const numericValue = Number(value);
-    if (!isNaN(numericValue)) {
-      newIngredients[index].quantity = numericValue;
-    }
-    setIngredients(newIngredients);
-  };
-
-  const handleUnitChange = (index: number, value: string) => {
-    const newIngredients = [...ingredients];
-    newIngredients[index].unitId = Number(value);
-    setIngredients(newIngredients);
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>, index: number) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      if (ingredients[index].ingredientId) {
-        setIngredients([...ingredients, { ingredientId: 0, quantity: 0, unitId: 0 }]);
-        setSearchTerm('');
-        setShowDropdown(false);
-        setTimeout(() => {
-          const inputs = document.querySelectorAll('.ingredient-input');
-          if (inputs.length > 0) {
-            (inputs[inputs.length - 1] as HTMLInputElement).focus();
-          }
-        }, 0);
-      }
-    }
-  };
-
-  return (
-    <div className="relative bg-white rounded-lg shadow-lg p-4 mt-6 w-1/2 min-h-[70vh]">
-      <h2 className="text-xl font-bold mb-4">Ingredients</h2>
-      {ingredients.map((ingredient, index) => (
-        <div key={index} className="flex items-center mb-2">
-          <span className="mr-2 font-semibold">{index + 1}.)</span>
-          <div className="relative flex-1">
-            <input
-              type="text"
-              placeholder="Search ingredient..."
-              value={activeIndex === index ? searchTerm : getIngredientName(ingredient.ingredientId)}
-              onChange={(e) => handleIngredientSearch(index, e.target.value)}
-              onKeyDown={(e) => handleKeyDown(e, index)}
-              className="w-full p-2 rounded focus:outline-none ingredient-input"
-            />
-            {showDropdown && activeIndex === index && (
-              <div className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded shadow-lg max-h-60 overflow-auto">
-                {ingredientsLoading ? (
-                  <div className="p-2">Loading ingredients...</div>
-                ) : ingredientsError ? (
-                  <div className="p-2">Error loading ingredients</div>
-                ) : filteredIngredients.length === 0 ? (
-                  <div className="p-2">No ingredients found</div>
-                ) : (
-                  filteredIngredients.map((ing) => (
-                    <div
-                      key={ing.id}
-                      className="p-2 hover:bg-gray-100 cursor-pointer"
-                      onClick={() => handleIngredientSelect(index, ing.id)}
-                    >
-                      {ing.name}
-                    </div>
-                  ))
-                )}
-              </div>
-            )}
-          </div>
-          <div className="flex items-center ml-2 border border-black rounded p-1">
-            <input
-              type="text"
-              placeholder="0"
-              value={ingredient.quantity === 0 ? '' : ingredient.quantity}
-              onChange={(e) => handleQuantityChange(index, e.target.value)}
-              className="w-12 p-1 outline-none"
-            />
-            <select
-              value={ingredient.unitId || 0}
-              onChange={(e) => handleUnitChange(index, e.target.value)}
-              className="p-1 outline-none"
-            >
-              <option value={0}>Select unit...</option>
-              {unitsLoading ? (
-                <option>Loading units...</option>
-              ) : unitsError ? (
-                <option>Error loading units</option>
-              ) : (
-                units?.map((unit) => (
-                  <option key={unit.id} value={unit.id}>
-                    {unit.name}
-                  </option>
-                ))
-              )}
-            </select>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-};
-
-interface InstructionsBoxProps {
-  instructions: string[];
-  setInstructions: (ins: string[]) => void;
-}
-
-const InstructionsBox: React.FC<InstructionsBoxProps> = ({ instructions, setInstructions }) => {
-  const handleInputChange = (index: number, value: string) => {
-    const newInstructions = [...instructions];
-    newInstructions[index] = value;
-    setInstructions(newInstructions);
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>, index: number) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      if (instructions[index].trim() !== '') {
-        setInstructions([...instructions, '']);
-        // Focus the new input after state update
-        setTimeout(() => {
-          const inputs = document.querySelectorAll('.instruction-input');
-          if (inputs.length > 0) {
-            (inputs[inputs.length - 1] as HTMLInputElement).focus();
-          }
-        }, 0);
-      }
-    }
-  };
-
-  return (
-    <div className="relative p-4 mt-6 w-1/2">
-      <h2 className="text-xl font-bold mb-4">Instructions</h2>
-      {instructions.map((step, index) => (
-        <div key={index} className="flex items-center mb-2">
-          <span className="mr-2 font-semibold">{index + 1}.)</span>
-          <input
-            type="text"
-            placeholder="add step..."
-            value={step}
-            onChange={(e) => handleInputChange(index, e.target.value)}
-            onKeyDown={(e) => handleKeyDown(e, index)}
-            className="flex-1 p-2 rounded focus:outline-none bg-transparent instruction-input"
-          />
-        </div>
-      ))}
-    </div>
-  );
 };
 
 const RecipeUpdatePage: React.FC = () => {
@@ -448,7 +242,7 @@ const RecipeUpdatePage: React.FC = () => {
           </span>
         </div>
         <div className="flex flex-row gap-8">
-          <IngredientsBox ingredients={ingredients} setIngredients={setIngredients} />
+          <IngredientsBox ingredients={ingredients} setIngredients={setIngredients} API_BASE={API_BASE} />
           <InstructionsBox instructions={instructions} setInstructions={setInstructions} />
         </div>
         <Box mt={4}>

--- a/frontend/src/pages/RecipeUpdatePage.tsx
+++ b/frontend/src/pages/RecipeUpdatePage.tsx
@@ -1,13 +1,13 @@
-import React, { useState, useEffect, KeyboardEvent, useCallback } from 'react';
+import React, { useState, useEffect, KeyboardEvent } from 'react';
 import { useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { Box, Button, Snackbar, Alert } from '@mui/material';
 import Sidebar from './Sidebar';
 
 interface IngredientEntry {
-  name: string;
+  ingredientId: number;
   quantity: number;
-  unit: string;
+  unitId: number;
 }
 
 interface RecipeData {
@@ -20,9 +20,11 @@ interface RecipeData {
   recipeIngredients: {
     quantity: string;
     ingredient: {
+      id: number;
       name: string;
     };
     unit: {
+      id: number;
       name: string;
     };
   }[];
@@ -36,35 +38,33 @@ interface RecipeData {
   }[];
 }
 
+interface Unit {
+  id: number;
+  name: string;
+  type: string;
+}
+
+interface Ingredient {
+  id: number;
+  name: string;
+  description?: string;
+  standardUnit?: number;
+  density?: number;
+}
+
 const API_BASE = import.meta.env.VITE_BACKEND_HOST || 'http://localhost:3001';
 
 const useFetchRecipe = (id: string) => {
-  const [recipe, setRecipe] = useState<RecipeData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  
-  const fetchRecipe = useCallback(async () => {
-    try {
+  return useQuery({
+    queryKey: ['recipe', id],
+    queryFn: async () => {
       const response = await fetch(`${API_BASE}/recipes/${id}`);
       if (!response.ok) {
-        throw new Error('Failed to fetch recipe');
+        throw new Error('Network response was not ok');
       }
-      const data = await response.json();
-      console.log('Fetched recipe data:', data);
-      setRecipe(data);
-    } catch (err: unknown) {
-      console.error('Error fetching recipe:', err);
-      setError((err as Error).message);
-    } finally {
-      setLoading(false);
-    }
-  }, [id]);
-
-  useEffect(() => {
-    fetchRecipe();
-  }, [id, fetchRecipe]);
-
-  return { recipe, loading, error, refetch: fetchRecipe };
+      return response.json();
+    },
+  });
 };
 
 const useUpdateRecipe = () => {
@@ -83,12 +83,6 @@ const useUpdateRecipe = () => {
   });
 };
 
-interface Unit {
-  unitID: number;
-  name: string;
-  type: string;
-}
-
 interface IngredientsBoxProps {
   ingredients: IngredientEntry[];
   setIngredients: (ings: IngredientEntry[]) => void;
@@ -103,21 +97,53 @@ const IngredientsBox: React.FC<IngredientsBoxProps> = ({ ingredients, setIngredi
     return response.json();
   };
 
-  const { data: standardUnits, isLoading: unitsLoading, error: unitsError } = useQuery<Unit[]>({
+  const fetchIngredients = async (): Promise<Ingredient[]> => {
+    const response = await fetch(`${API_BASE}/ingredients`);
+    if (!response.ok) {
+      throw new Error('Failed to fetch ingredients');
+    }
+    return response.json();
+  };
+
+  const { data: units, isLoading: unitsLoading, error: unitsError } = useQuery<Unit[]>({
     queryKey: ['units'],
     queryFn: fetchUnits,
   });
 
-  const handleNameChange = (index: number, value: string) => {
+  const { data: availableIngredients, isLoading: ingredientsLoading, error: ingredientsError } = useQuery<Ingredient[]>({
+    queryKey: ['ingredients'],
+    queryFn: fetchIngredients,
+  });
+
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [showDropdown, setShowDropdown] = useState<boolean>(false);
+  const [activeIndex, setActiveIndex] = useState<number>(-1);
+
+  const filteredIngredients = availableIngredients?.filter(ing => 
+    ing.name.toLowerCase().includes(searchTerm.toLowerCase())
+  ) || [];
+
+  const getIngredientName = (ingredientId: number) => {
+    return availableIngredients?.find(i => i.id === ingredientId)?.name || '';
+  };
+
+  const handleIngredientSearch = (index: number, value: string) => {
+    setSearchTerm(value);
+    setShowDropdown(true);
+    setActiveIndex(index);
+  };
+
+  const handleIngredientSelect = (index: number, ingredientId: number) => {
     const newIngredients = [...ingredients];
-    newIngredients[index].name = value;
+    newIngredients[index].ingredientId = ingredientId;
     setIngredients(newIngredients);
+    setSearchTerm(getIngredientName(ingredientId));
+    setShowDropdown(false);
   };
 
   const handleQuantityChange = (index: number, value: string) => {
     const newIngredients = [...ingredients];
     const numericValue = Number(value);
-    // Only update if the value is a valid number
     if (!isNaN(numericValue)) {
       newIngredients[index].quantity = numericValue;
     }
@@ -126,16 +152,17 @@ const IngredientsBox: React.FC<IngredientsBoxProps> = ({ ingredients, setIngredi
 
   const handleUnitChange = (index: number, value: string) => {
     const newIngredients = [...ingredients];
-    newIngredients[index].unit = value;
+    newIngredients[index].unitId = Number(value);
     setIngredients(newIngredients);
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>, index: number) => {
     if (e.key === 'Enter') {
       e.preventDefault();
-      if (ingredients[index].name.trim() !== '') {
-        setIngredients([...ingredients, { name: '', quantity: 0, unit: '' }]);
-        // Focus the new input after state update
+      if (ingredients[index].ingredientId) {
+        setIngredients([...ingredients, { ingredientId: 0, quantity: 0, unitId: 0 }]);
+        setSearchTerm('');
+        setShowDropdown(false);
         setTimeout(() => {
           const inputs = document.querySelectorAll('.ingredient-input');
           if (inputs.length > 0) {
@@ -152,35 +179,58 @@ const IngredientsBox: React.FC<IngredientsBoxProps> = ({ ingredients, setIngredi
       {ingredients.map((ingredient, index) => (
         <div key={index} className="flex items-center mb-2">
           <span className="mr-2 font-semibold">{index + 1}.)</span>
-          <input
-            type="text"
-            placeholder="add ingredient..."
-            value={ingredient.name}
-            onChange={(e) => handleNameChange(index, e.target.value)}
-            onKeyDown={(e) => handleKeyDown(e, index)}
-            className="flex-1 p-2 rounded focus:outline-none ingredient-input"
-          />
+          <div className="relative flex-1">
+            <input
+              type="text"
+              placeholder="Search ingredient..."
+              value={activeIndex === index ? searchTerm : getIngredientName(ingredient.ingredientId)}
+              onChange={(e) => handleIngredientSearch(index, e.target.value)}
+              onKeyDown={(e) => handleKeyDown(e, index)}
+              className="w-full p-2 rounded focus:outline-none ingredient-input"
+            />
+            {showDropdown && activeIndex === index && (
+              <div className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded shadow-lg max-h-60 overflow-auto">
+                {ingredientsLoading ? (
+                  <div className="p-2">Loading ingredients...</div>
+                ) : ingredientsError ? (
+                  <div className="p-2">Error loading ingredients</div>
+                ) : filteredIngredients.length === 0 ? (
+                  <div className="p-2">No ingredients found</div>
+                ) : (
+                  filteredIngredients.map((ing) => (
+                    <div
+                      key={ing.id}
+                      className="p-2 hover:bg-gray-100 cursor-pointer"
+                      onClick={() => handleIngredientSelect(index, ing.id)}
+                    >
+                      {ing.name}
+                    </div>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
           <div className="flex items-center ml-2 border border-black rounded p-1">
             <input
               type="text"
-              placeholder='0'
+              placeholder="0"
               value={ingredient.quantity === 0 ? '' : ingredient.quantity}
               onChange={(e) => handleQuantityChange(index, e.target.value)}
               className="w-12 p-1 outline-none"
             />
             <select
-              value={ingredient.unit}
+              value={ingredient.unitId || 0}
               onChange={(e) => handleUnitChange(index, e.target.value)}
               className="p-1 outline-none"
             >
-              <option value="">--</option>
+              <option value={0}>Select unit...</option>
               {unitsLoading ? (
                 <option>Loading units...</option>
               ) : unitsError ? (
                 <option>Error loading units</option>
               ) : (
-                standardUnits?.map((unit: Unit) => (
-                  <option key={unit.unitID} value={unit.unitID}>
+                units?.map((unit) => (
+                  <option key={unit.id} value={unit.id}>
                     {unit.name}
                   </option>
                 ))
@@ -243,16 +293,44 @@ const InstructionsBox: React.FC<InstructionsBoxProps> = ({ instructions, setInst
 
 const RecipeUpdatePage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
-  const { recipe, loading, error, refetch } = useFetchRecipe(id!);
+  const { data: recipe, isLoading, error, refetch } = useFetchRecipe(id!);
   const updateMutation = useUpdateRecipe();
   const [showSuccess, setShowSuccess] = useState(false);
+
+  const fetchUnits = async (): Promise<Unit[]> => {
+    const response = await fetch(`${API_BASE}/units`);
+    if (!response.ok) {
+      throw new Error('Failed to fetch units');
+    }
+    return response.json();
+  };
+
+  const fetchIngredients = async (): Promise<Ingredient[]> => {
+    const response = await fetch(`${API_BASE}/ingredients`);
+    if (!response.ok) {
+      throw new Error('Failed to fetch ingredients');
+    }
+    return response.json();
+  };
+
+  const { data: units, isLoading: unitsLoading } = useQuery<Unit[]>({
+    queryKey: ['units'],
+    queryFn: fetchUnits,
+  });
+
+  const { data: availableIngredients, isLoading: ingredientsLoading } = useQuery<Ingredient[]>({
+    queryKey: ['ingredients'],
+    queryFn: fetchIngredients,
+  });
 
   const [name, setName] = useState<string>('');
   const [description, setDescription] = useState<string>('');
   const [date, setDate] = useState<string>('');
   const [link, setLink] = useState<string>('');
   const [isEditingLink, setIsEditingLink] = useState<boolean>(false);
-  const [ingredients, setIngredients] = useState<IngredientEntry[]>([{ name: '', quantity: 0, unit: '' }]);
+  const [ingredients, setIngredients] = useState<IngredientEntry[]>([
+    { ingredientId: 0, quantity: 0, unitId: 0 },
+  ]);
   const [instructions, setInstructions] = useState<string[]>(['']);
   const headerImage = recipe?.headerImage || "/default.jpg";
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -263,17 +341,17 @@ const RecipeUpdatePage: React.FC = () => {
       setDescription(recipe.description);
       setDate(recipe.date);
       setLink(recipe.link);
-      setIngredients(recipe.recipeIngredients.map(ing => ({
-        name: ing.ingredient.name,
+      setIngredients(recipe.recipeIngredients.map((ing: RecipeData['recipeIngredients'][0]) => ({
+        ingredientId: ing.ingredient.id,
         quantity: parseFloat(ing.quantity),
-        unit: ing.unit.name
+        unitId: ing.unit.id
       })));
-      setInstructions(recipe.recipeSteps.map(step => step.step.stepText));
+      setInstructions(recipe.recipeSteps.map((step: RecipeData['recipeSteps'][0]) => step.step.stepText));
     }
   }, [recipe]);
 
   const handleUpdate = () => {
-    if (recipe) {
+    if (recipe && units && availableIngredients) {
       const updatedRecipe: RecipeData = {
         ...recipe,
         name,
@@ -282,14 +360,16 @@ const RecipeUpdatePage: React.FC = () => {
         link,
         headerImage,
         recipeIngredients: ingredients
-          .filter(ing => ing.name.trim() !== '')
+          .filter(ing => ing.ingredientId !== 0)
           .map(ing => ({
             quantity: ing.quantity.toString(),
             ingredient: {
-              name: ing.name
+              id: ing.ingredientId,
+              name: availableIngredients.find(i => i.id === ing.ingredientId)?.name || ''
             },
             unit: {
-              name: ing.unit
+              id: ing.unitId,
+              name: units.find(u => u.id === ing.unitId)?.name || ''
             }
           })),
         recipeSteps: instructions
@@ -312,9 +392,9 @@ const RecipeUpdatePage: React.FC = () => {
     }
   };
 
-  if (loading) return <p>Loading...</p>;
-  if (error) return <p>Error: {error}</p>;
-  if (!recipe) return <p>Recipe not found.</p>;
+  if (isLoading || unitsLoading || ingredientsLoading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+  if (!recipe || !units || !availableIngredients) return <p>Recipe not found.</p>;
 
   return (
     <div className="flex min-h-screen bg-gray-100 font-sans text-[#7B8A64]">

--- a/frontend/src/pages/RecipeUpdatePage.tsx
+++ b/frontend/src/pages/RecipeUpdatePage.tsx
@@ -125,7 +125,7 @@ const RecipeUpdatePage: React.FC = () => {
   const [ingredients, setIngredients] = useState<IngredientEntry[]>([
     { ingredientId: 0, quantity: 0, unitId: 0 },
   ]);
-  const [instructions, setInstructions] = useState<string[]>(['']);
+  const [instructions, setInstructions] = useState<Array<{stepId: number; stepNumber: number; stepText: string}>>([]);
   const headerImage = recipe?.headerImage || "/default.jpg";
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
@@ -140,7 +140,11 @@ const RecipeUpdatePage: React.FC = () => {
         quantity: parseFloat(ing.quantity),
         unitId: ing.unit.id
       })));
-      setInstructions(recipe.recipeSteps.map((step: RecipeData['recipeSteps'][0]) => step.step.stepText));
+      setInstructions(recipe.recipeSteps.map((step: RecipeData['recipeSteps'][0]) => ({
+        stepId: step.stepId,
+        stepNumber: step.step.stepNumber,
+        stepText: step.step.stepText
+      })));
     }
   }, [recipe]);
 
@@ -167,13 +171,13 @@ const RecipeUpdatePage: React.FC = () => {
             }
           })),
         recipeSteps: instructions
-          .filter(step => step.trim() !== '')
-          .map((stepText, index) => ({
+          .filter(step => step.stepText.trim() !== '')
+          .map(step => ({
             recipeId: recipe.id,
-            stepId: index + 1,
+            stepId: step.stepId,
             step: {
-              stepNumber: index + 1,
-              stepText
+              stepNumber: step.stepNumber,
+              stepText: step.stepText
             }
           }))
       };

--- a/frontend/src/types/recipeFormData.ts
+++ b/frontend/src/types/recipeFormData.ts
@@ -1,6 +1,6 @@
 export type RecipeFormData = {
     name: string;
     description: string;
-    ingredients: { name: string; quantity: number; unit: string }[];
+    ingredients: { ingredientId: number; quantity: number; unitId: number }[];
     steps: { stepNumber: number; stepText: string }[];
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Makes it so that ingredient and unit are passed as ids instead of strings. Also standardizes to make sure everything has a standard unit (and density optionally)

Primary changes of note:
- make it so that ingredients is a searchable drop down
- add a create new ingredient option to the searchable drop down
- only show units that the ingredient can be converted into
- update the recipe creation endpoint to take in ingredientid and unitid instead of string

on the side:
 - make step text wrap around instead of overflow
 - make steps show up in their sorted order

## Related Issue

resolves #52

## Motivation and Context

We need everything to be standardized to make aggregating recipes and saving owned ingredients better

## How Has This Been Tested?

tested manually to make sure standard units are required

## Screenshots (if appropriate):
