### PR TITLE
Added simple AI endpoint

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,4 @@ PG_HOST=host
 DB_NAME=db_name
 PG_PASSWORD=password
 PG_PORT=5432
+GEMINI_API_KEY=your_gemini_api_key

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@google/generative-ai": "^0.24.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
@@ -1242,6 +1243,14 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.0.tgz",
+      "integrity": "sha512-fnEITCGEB7NdX0BhoYZ/cq/7WPZ1QS5IzJJfC3Tg/OwkvBetMiVJciyaan297OvE4B9Jg1xvo0zIazX/9sGu1Q==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
     "seed": "tsx ./db_setup_scripts/seed/runSeed.ts"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.24.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,9 +7,11 @@ import aggregationRouter from './routes/aggregation';
 import ingredientsRouter from './routes/ingredients';
 import unitsRouter from './routes/units';
 import recipesRouter from './routes/recipes';
+import aiRecipesRouter from './routes/aiRecipes';
 
 const app: Express = express();
 
+app.use(express.text({ type: 'text/plain' }));
 app.use(express.json());
 app.use(cors());
 if(process.env.NODE_ENV !== 'test') {
@@ -45,6 +47,7 @@ app.use('/ownedIngredients', ownedIngredientsRouter);
 app.use('/aggregation', aggregationRouter);
 app.use('/units', unitsRouter);
 app.use('/recipes', recipesRouter);
+app.use('/ai-recipes', aiRecipesRouter);
 app.use('/ingredients', ingredientsRouter);
 
 /**

--- a/backend/src/controllers/aiRecipe.ts
+++ b/backend/src/controllers/aiRecipe.ts
@@ -1,0 +1,63 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { RecipeFormData } from 'types/recipeFormData';
+
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '');
+
+const PROMPT_TEMPLATE = `
+Extract the following information from the recipe text and format it as JSON:
+1. Recipe name - Extract ONLY the name of the food/dish, not the full title. For example:
+   - If title is "The Best Chocolate Chip Cookies Recipe", name should be "Chocolate Chip Cookies"
+   - If title is "Easy Homemade Pizza Dough", name should be "Pizza Dough"
+   - If title is "How to Make Italian Sausage and Peppers", name should be "Italian Sausage and Peppers"
+2. Recipe description - Keep the description brief, no more than 50 words.
+3. List of ingredients with:
+   - ingredient name
+   - quantity
+   - unit (use the following unit IDs: g=1, kg=2, oz=3, lb=4, mg=5, ml=6, l=7, tsp=8, tbsp=9, cup=10, quart=11, pint=12, fl oz=13, dash=14, pinch=15, piece=16, slice=17, can=18, bottle=19, unit=20)
+4. List of steps with:
+   - step number
+   - step text
+
+Format the response as a JSON object with the following structure:
+{
+  "name": "string",
+  "description": "string",
+  "ingredients": [
+    {
+      "name": "string",
+      "quantity": number,
+      "unit": number
+    }
+  ],
+  "steps": [
+    {
+      "stepNumber": number,
+      "stepText": "string"
+    }
+  ]
+}
+
+Recipe text:
+{recipeText}
+`;
+
+//TODO: Edit prompt for ingredients names to be standardized
+
+export const extractRecipeFromText = async (recipeText: string): Promise<RecipeFormData> => {
+    try {
+        const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' });
+        const prompt = PROMPT_TEMPLATE.replace('{recipeText}', recipeText);
+        
+        const result = await model.generateContent(prompt);
+        const response = await result.response;
+        const text = response.text();
+        
+        const cleanedText = text.replace(/^```json\s*|\s*```$/g, '');
+        
+        const recipeData = JSON.parse(cleanedText) as RecipeFormData;
+        return recipeData;
+    } catch (error) {
+        console.error('Error extracting recipe:', error);
+        throw new Error('Failed to extract recipe from text');
+    }
+}; 

--- a/backend/src/routes/aiRecipes.ts
+++ b/backend/src/routes/aiRecipes.ts
@@ -1,0 +1,35 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { extractRecipeFromText } from '../controllers/aiRecipe';
+
+const router = Router();
+
+/**
+ * @brief endpoint for extracting recipe data from text
+ */
+router.post('/extract', async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const contentType = req.headers['content-type'];
+        let recipeText: string;
+
+        if (contentType?.includes('text/plain')) {
+            recipeText = req.body as string;
+        } else if (contentType?.includes('application/json')) {
+            recipeText = req.body.recipeText;
+        } else {
+            res.status(400).json({ error: 'Content-Type must be text/plain or application/json' });
+            return;
+        }
+
+        if (!recipeText) {
+            res.status(400).json({ error: 'recipeText is required' });
+            return;
+        }
+
+        const recipeData = await extractRecipeFromText(recipeText);
+        res.status(200).json(recipeData);
+    } catch (error) {
+        next(error);
+    }
+});
+
+export default router; 

--- a/backend/tests/routes/aiRecipes.test.ts
+++ b/backend/tests/routes/aiRecipes.test.ts
@@ -1,0 +1,90 @@
+import request from 'supertest';
+import app from '../../src/app';
+import { extractRecipeFromText } from '../../src/controllers/aiRecipe';
+
+// Mock the AI recipe controller function
+jest.mock('../../src/controllers/aiRecipe');
+
+describe('AI Recipes Routes', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('POST /extract', () => {
+        it('should extract recipe data from text and return valid RecipeFormData', async () => {
+            const mockRecipeData = {
+                name: 'Chocolate Chip Cookies',
+                description: 'Classic chocolate chip cookies that are soft and chewy.',
+                ingredients: [
+                    { name: 'all-purpose flour', quantity: 2.25, unit: 10 },
+                    { name: 'baking soda', quantity: 1, unit: 8 },
+                    { name: 'salt', quantity: 1, unit: 8 },
+                    { name: 'butter', quantity: 1, unit: 10 },
+                    { name: 'granulated sugar', quantity: 0.75, unit: 10 },
+                    { name: 'brown sugar', quantity: 0.75, unit: 10 },
+                    { name: 'vanilla extract', quantity: 1, unit: 8 },
+                    { name: 'eggs', quantity: 2, unit: 20 },
+                    { name: 'chocolate chips', quantity: 2, unit: 10 }
+                ],
+                steps: [
+                    { stepNumber: 1, stepText: 'Preheat oven to 375°F.' },
+                    { stepNumber: 2, stepText: 'Combine flour, baking soda and salt in small bowl.' },
+                    { stepNumber: 3, stepText: 'Beat butter, granulated sugar, brown sugar and vanilla extract in large mixer bowl until creamy.' },
+                    { stepNumber: 4, stepText: 'Add eggs, one at a time, beating well after each addition.' },
+                    { stepNumber: 5, stepText: 'Gradually beat in flour mixture.' },
+                    { stepNumber: 6, stepText: 'Stir in chocolate chips.' },
+                    { stepNumber: 7, stepText: 'Drop by rounded tablespoon onto ungreased baking sheets.' },
+                    { stepNumber: 8, stepText: 'Bake for 9 to 11 minutes or until golden brown.' },
+                    { stepNumber: 9, stepText: 'Cool on baking sheets for 2 minutes; remove to wire racks to cool completely.' }
+                ]
+            };
+
+            (extractRecipeFromText as jest.Mock).mockResolvedValue(mockRecipeData);
+
+            const recipeText = `Classic Chocolate Chip Cookies
+
+These delicious cookies are a family favorite. They're soft, chewy, and packed with chocolate chips.
+
+Ingredients:
+- 2 1/4 cups all-purpose flour
+- 1 teaspoon baking soda
+- 1 teaspoon salt
+- 1 cup (2 sticks) butter, softened
+- 3/4 cup granulated sugar
+- 3/4 cup packed brown sugar
+- 1 teaspoon vanilla extract
+- 2 large eggs
+- 2 cups (12-oz. pkg.) semi-sweet chocolate chips
+
+Steps:
+1. Preheat oven to 375°F.
+2. Combine flour, baking soda and salt in small bowl.
+3. Beat butter, granulated sugar, brown sugar and vanilla extract in large mixer bowl until creamy.
+4. Add eggs, one at a time, beating well after each addition.
+5. Gradually beat in flour mixture.
+6. Stir in chocolate chips.
+7. Drop by rounded tablespoon onto ungreased baking sheets.
+8. Bake for 9 to 11 minutes or until golden brown.
+9. Cool on baking sheets for 2 minutes; remove to wire racks to cool completely.`;
+
+            const response = await request(app)
+                .post('/ai-recipes/extract')
+                .set('Content-Type', 'text/plain')
+                .send(recipeText);
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual(mockRecipeData);
+            expect(extractRecipeFromText).toHaveBeenCalledWith(recipeText);
+        });
+
+        it('should return 400 for missing recipeText', async () => {
+            const response = await request(app)
+                .post('/ai-recipes/extract')
+                .set('Content-Type', 'text/plain')
+                .send('');
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBe('recipeText is required');
+        });
+    });
+}); 


### PR DESCRIPTION
## Description
- Adds endpoint `/ai-recipes/extract` that can take in a JSON of recipeText or a simple string body to get an appropriate JSON according to our `RecipeFormData` data type.
- Returns `RecipeFormData` back as a JSON.
- Added simple test for one case of extract.
- Added prompt to iterate on (next issue to standardize ingredient names)

## Related Issue
Closes #56 

## Motivation and Context
This was a necessary feature for our next text upload feature.

## How Has This Been Tested?
- Ran against multiple different recipe websites with structured text
- Ran with CTRL-A (select all text) on random recipe websites

